### PR TITLE
Update PRD and phase plan for 5-city launch and Next.js+Elysia monorepo

### DIFF
--- a/PHASES.md
+++ b/PHASES.md
@@ -7,7 +7,7 @@
 - Stay inside MVP scope unless the PRD is explicitly updated first.
 - Complete phases in order unless a dependency-free task is clearly safe to parallelize.
 - Mark progress by updating status labels, not by adding ad hoc notes everywhere.
-- Do not introduce new stack decisions unless they support the PRD direction: Next.js, Clerk, Postgres, Drizzle, UploadThing, Zod, Tailwind.
+- Do not introduce new stack decisions unless they support the PRD direction: Next.js (frontend), Elysia.js (backend), Clerk, Postgres, Drizzle, UploadThing, Zod, Tailwind.
 
 ## Status Key
 
@@ -46,23 +46,26 @@
 
 - Status: `Done`
 - Objective: establish the new technical foundation for Recycly.
-- Completion target: a runnable Next.js app shell exists with the chosen core stack wired up.
+- Completion target: a runnable monorepo foundation exists with frontend app surfaces and an Elysia.js backend service scaffold.
 - Prerequisites: Phase 0 done.
 
 ### Checklist
 
 - Refresh `package.json` for the new stack and remove legacy dependencies.
-- Scaffold the fresh Next.js App Router structure.
+- Scaffold monorepo app/service layout (landing, dashboard, docs, backend).
+- Scaffold Next.js App Router structure for frontend surfaces.
+- Scaffold Elysia.js API service.
 - Set up TypeScript, Tailwind, and base linting conventions.
 - Integrate Clerk authentication.
-- Establish route groups for public, app, and docs surfaces.
+- Establish frontend app boundaries for public, dashboard, and docs surfaces.
+- Define frontend-to-backend API integration boundary.
 - Define the initial design system direction and layout shell.
 - Add environment variable templates and setup notes for the new stack.
 
 ### Definition Of Done
 
-- The app runs locally on the new stack.
-- Public and authenticated route groups exist.
+- Frontend apps and backend API service run locally in the monorepo.
+- Public, dashboard, and docs surfaces are clearly separated.
 - Clerk is wired and ready for role-based access work.
 - The codebase no longer reflects the deleted legacy architecture.
 - Validation complete: `pnpm check`, `pnpm typecheck`, and `pnpm build` all pass.
@@ -85,13 +88,13 @@
 - Add Drizzle and define the initial schema for core entities.
 - Model the four MVP roles: User, Collector, Staff, Super Admin.
 - Define pickup, verification, redemption, support, and dispute status models.
-- Add server-side authorization guards and role checks.
+- Add backend authorization guards and role checks in Elysia middleware and service layer.
 - Add UploadThing foundations for proof uploads and attachments.
 
 ### Definition Of Done
 
 - Core tables/entities are represented in Drizzle.
-- Role-restricted access rules are enforceable in the app layer.
+- Role-restricted access rules are enforceable at backend API and frontend route access layers.
 - UploadThing is ready for operational file flows.
 - Validation complete: `pnpm db:generate`, `pnpm check`, `pnpm typecheck`, and `pnpm build` all pass.
 
@@ -117,6 +120,7 @@
 - Implement location-based assignment logic.
 - Add collector job acceptance and status updates.
 - Add proof upload flow for completed pickups.
+- Ensure all workflow mutations are executed through Elysia backend endpoints (no Next.js API routes).
 
 ### Definition Of Done
 
@@ -170,7 +174,7 @@
 ### Checklist
 
 - Build the landing page and core public marketing sections.
-- Add docs/help content inside the main app codebase.
+- Add docs/help content in a separate docs app within the monorepo.
 - Add trust, FAQ, and how-it-works pages.
 - Improve empty states, errors, loading states, and mobile responsiveness.
 - Add notification flows for important user and staff events.
@@ -180,6 +184,7 @@
 ### Definition Of Done
 
 - Public and authenticated experiences both feel intentional and coherent.
+- Monorepo app separation (landing, dashboard, docs, backend) is production-ready and documented.
 - Core help and docs content exists.
 - MVP acceptance criteria from the PRD can be validated end to end.
 

--- a/PRD.md
+++ b/PRD.md
@@ -192,7 +192,7 @@ Suggested launch categories:
 - Super Admin access management
 - Reward rule management
 - Public marketing pages
-- Product documentation inside the main app
+- Product documentation as a dedicated docs app within the monorepo
 
 ### 10.2 Out of scope
 
@@ -561,7 +561,7 @@ Mitigation:
 Mitigation:
 
 - keep collector matching simple
-- start with one city assumption
+- start with city-level scoping across the five defined launch cities
 - abstract map vendor decisions
 
 ### Risk: payout complexity
@@ -622,7 +622,7 @@ Mitigation:
 
 - Product name must be written as `Recycly`.
 - This is a full rebuild, not a migration.
-- MVP launch context is Lagos-first within Nigeria urban operations.
+- MVP launch context is a five-city Nigerian urban rollout: Benin City, Lagos, Abuja, Ibadan, and Port Harcourt.
 - Staff absorbs admin-like operational duties for MVP.
 - Rewards are points-first, with reviewed redemption.
 - UploadThing is the default upload and object handling solution.

--- a/PRD.md
+++ b/PRD.md
@@ -5,7 +5,7 @@
 - Product: Recycly
 - Version: 1.0
 - Status: Draft for implementation
-- Last updated: 2026-03-13
+- Last updated: 2026-04-05
 - Product type: Production-style side project with real operational workflows
 
 ## Delivery Status Legend
@@ -68,7 +68,7 @@ The following are explicitly out of scope for MVP:
 - Municipality or enterprise portals
 - Advanced fraud detection systems beyond basic controls
 - Deep partnership management workflows
-- Astro or multi-app monorepo architecture
+- Astro framework usage for core product surfaces
 
 ## 6. Product Principles
 
@@ -85,7 +85,7 @@ The following are explicitly out of scope for MVP:
 
 - Geography: Nigeria
 - Launch context: urban operations
-- Initial city assumption: Lagos
+- Initial launch cities (phase 1 operations): Benin City, Lagos, Abuja, Ibadan, and Port Harcourt
 
 ### Target users
 
@@ -306,7 +306,7 @@ Suggested launch categories:
 ### 12.9 Public product content
 
 - The app must include a marketing-facing landing experience.
-- The app must include basic docs/help content in the same codebase.
+- The monorepo must include basic docs/help content as a dedicated docs surface.
 - Docs should help users understand supported waste, pickup flow, rewards, and support.
 
 ## 13. Data Model Direction
@@ -434,6 +434,7 @@ Deferred channels:
 ### Scalability
 
 - MVP architecture must not block later growth into more cities, more staff, or more reward types.
+- Initial launch operations and reporting must support city-level filtering for Benin City, Lagos, Abuja, Ibadan, and Port Harcourt.
 
 ## 18. Recommended Technical Stack
 
@@ -441,7 +442,8 @@ Recycly should be rebuilt on a fresh stack using the latest stable versions at i
 
 ### Required stack decisions
 
-- Framework: Next.js App Router
+- Frontend framework: Next.js App Router
+- Backend framework: Elysia.js (TypeScript)
 - Language: TypeScript
 - Auth: Clerk
 - Database: Postgres
@@ -452,8 +454,13 @@ Recycly should be rebuilt on a fresh stack using the latest stable versions at i
 
 ### Architecture decisions
 
-- One Next.js codebase for landing pages, app, and docs
-- Route groups used to separate public and authenticated experiences
+- Monorepo architecture with separate apps/services for:
+  - landing page frontend
+  - dashboard frontend
+  - docs frontend
+  - Elysia.js backend API
+- No Next.js API routes for business logic (API responsibilities belong to the Elysia backend service)
+- Shared packages for domain types, validation schemas, UI primitives, and configuration where helpful
 - Server-first data patterns where appropriate
 - Background jobs used for notifications, assignment fanout, and redemption processing
 - Map and geocoding provider kept abstract so vendors can change later
@@ -487,11 +494,16 @@ Reference links:
 
 ### Authenticated app
 
-- User dashboard
-- Collector dashboard
-- Staff dashboard
-- Super Admin dashboard
+- User dashboard (separate frontend app)
+- Collector dashboard (separate frontend app or scoped dashboard module)
+- Staff dashboard (separate frontend app or scoped dashboard module)
+- Super Admin dashboard (separate frontend app or scoped dashboard module)
 - Shared settings and profile area
+
+### Backend API surface
+
+- Elysia.js service exposes endpoints for auth-integrated user workflows, pickup lifecycle, verification, rewards, disputes, and admin operations.
+- Frontend apps communicate with backend over HTTP APIs (or RPC-style wrappers), not Next.js inbuilt API routes.
 
 ## 20. MVP Acceptance Criteria
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ This repository is now in a fresh rebuild phase. The legacy implementation has b
 
 ## Intended Stack
 
-- Next.js App Router
+- Monorepo architecture with separate apps/services
+- Next.js App Router (frontend apps)
+- Elysia.js (backend API service)
 - TypeScript
 - Clerk
 - Postgres
@@ -31,4 +33,4 @@ This repository is now in a fresh rebuild phase. The legacy implementation has b
 
 ## Next Step
 
-Begin with Phase 1 in [PHASES.md](./PHASES.md): refresh the app foundation, wire the new stack, and establish the route and auth architecture for the fresh build.
+Begin with Phase 1 in [PHASES.md](./PHASES.md): finalize monorepo app boundaries (landing, dashboard, docs, backend), wire frontend/backend contracts, and establish auth architecture for the fresh build.


### PR DESCRIPTION
## Summary
- updated `PRD.md` launch context from a single-city assumption to five initial Nigerian cities: Benin City, Lagos, Abuja, Ibadan, and Port Harcourt
- revised PRD architecture direction to a monorepo with separate landing, dashboard, docs, and Elysia.js backend services
- explicitly documented that business APIs should live in the Elysia backend (no Next.js API routes for core business logic)
- refreshed functional and scalability notes to align with city-level operations and dedicated docs surface
- updated `PHASES.md` to reflect monorepo scaffolding, frontend/backend boundaries, and backend-first authorization/workflow execution
- aligned `README.md` intended stack and next-step guidance with the new architecture

## Testing
- not run (documentation/planning updates only)

## Notes
- no runtime or code-path changes were made; this PR focuses on product and execution documentation alignment

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2d56fe054832ea3aa6a0795d7a7e0)